### PR TITLE
Add markdown-links extension to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -20,6 +20,9 @@
 
     // [[wiki-links]], backlinking etc
     "kortina.vscode-markdown-notes",
+    
+    // Adds `show graph` command that displays graph of linked notes
+    "tchayen.markdown-links",
 
     // Understated grayscale theme (light and dark variants)
     "philipbe.theme-gray-matter"


### PR DESCRIPTION
The [Recommended list of extensions on the Foam site](https://foambubble.github.io/foam/recommended-extensions) includes [Markdown links](https://marketplace.visualstudio.com/items?itemName=tchayen.markdown-links) in the list. 

The template doesn't have Markdown links as a recommendation so it could be confusing to new comers why `Show Graph` isn't showing up correctly.

![](https://media1.giphy.com/media/1MayKbFuSKE1O/giphy.gif?cid=5a38a5a2d547c92d84b63f28ac7849d216a3e48ca733d062&rid=giphy.gif)
