### PR TITLE
Clarify how the repository should be opened in VS Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,9 @@ This documentation assumes that you have a GitHub account and have [Visual Studi
 1. If you haven't yet, browse over to the main [Foam documentation workspace](https://foambubble.github.io/foam) to get an idea of what Foam is and how to use it.
 2. Press "Use this template" button at [foam-template](https://github.com/foambubble/foam-template/generate) (that's this repository!) to fork it to your own GitHub account. If you want to keep your thoughts to yourself, remember to set the repository private.
 3. [Clone the repository to your local machine](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) and open it in VS Code.
+
+   ⚠️ *Open the repository as a folder. In VS Code, opening a workspace refers to [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces).*
+
 4. When prompted to install recommended extensions, click **Install all** (or **Show Recommendations** if you want to review and install them one by one)
 
 After setting up the repository, open [.vscode/settings.json](.vscode/settings.json) and edit, add or remove any settings you'd like for your Foam workspace.
@@ -26,7 +29,7 @@ We've created a few Bubbles (markdown documents) to get you started.
 
 ## Note on `[[wiki-links]]`
 
-⚠️ Until [foambubble/foam#16](https://github.com/foambubble/foam/issues/16) is resolved, `[[wiki-links]]` links (like the links above) won't work in the GitHub Markdown preview (i.e. this Readme on github.com). 
+⚠️ Until [foambubble/foam#16](https://github.com/foambubble/foam/issues/16) is resolved, `[[wiki-links]]` links (like the links above) won't work in the GitHub Markdown preview (i.e. this Readme on github.com).
 
 They should work as expected in VS Code, and in rendered GitHub Pages.
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This documentation assumes that you have a GitHub account and have [Visual Studi
 2. Press "Use this template" button at [foam-template](https://github.com/foambubble/foam-template/generate) (that's this repository!) to fork it to your own GitHub account. If you want to keep your thoughts to yourself, remember to set the repository private.
 3. [Clone the repository to your local machine](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) and open it in VS Code.
 
-   ⚠️ *Open the repository as a folder. In VS Code, opening a workspace refers to [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces).*
+    *Open the repository as a folder using the `File > Open...` menu item. In VS Code, "open workspace" refers to [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces).*
 
 4. When prompted to install recommended extensions, click **Install all** (or **Show Recommendations** if you want to review and install them one by one)
 


### PR DESCRIPTION
In the documentation, Foam refers to the template as a workspace, which makes sense given how it's meant to be used. However, in VS Code workspaces are a bit odd, each folder is considered a workspace (where settings and such are stored in the root's .vscode folder), yet there is also the option to 'Open Workspace' which refers to multi-root workspaces, a feature designed to allow you to have multiple folders open at the same time which requires the `workspace-name.code-workspace` file used to track the workspace folders and settings.

For users unaware of this distinction that assume the folder should be opened as a workspace, it can be a point of confusion, hence I've added a clarifying note and a link to the VS Code documentation that describes in detail how workspaces actually work.