### PR TITLE
Update markdown notes autosuggest default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "editor.quickSuggestions": true
   },
   "git.enableSmartCommit": true,
-  "git.postCommitCommand": "sync"
+  "git.postCommitCommand": "sync",
+  "vscodeMarkdownNotes.noteCompletionConvention": "noExtension"
 }


### PR DESCRIPTION
Updates the default markdown notes settings in the settings.json to suggest without the `.md` extension saving needless backspaces!