### PR TITLE
Auto detect color scheme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "editor.wrappingIndent": "indent",
   "editor.overviewRulerBorder": false,
   "editor.lineHeight": 24,
+  "workbench.colorTheme": "Gray Matter Light",
   "window.autoDetectColorScheme": true,
   "workbench.preferredLightColorTheme": "Gray Matter Light",
   "workbench.preferredDarkColorTheme": "Gray Matter Dark",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,9 @@
   "editor.wrappingIndent": "indent",
   "editor.overviewRulerBorder": false,
   "editor.lineHeight": 24,
-  "workbench.colorTheme": "Gray Matter Light",
+  "window.autoDetectColorScheme": true,
+  "workbench.preferredLightColorTheme": "Gray Matter Light",
+  "workbench.preferredDarkColorTheme": "Gray Matter Dark",
   "[markdown]": {
     "editor.quickSuggestions": true
   },


### PR DESCRIPTION
Provide (arguably) better experience by following preferred system theme ✨

![ezgif-7-adf615ff79ae](https://user-images.githubusercontent.com/1024980/89132881-02bf9080-d520-11ea-922c-710413b23d15.gif)

## Update:

I noticed that this feature actually writes theme changes to settings.json, so they'll constantly reappear as unstaged in git and sneak into commits. That might be unfortunate.