### PR TITLE
Fix "Recipes" link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ This documentation assumes that you have a GitHub account and have [Visual Studi
 
 After setting up the repository, open [.vscode/settings.json](.vscode/settings.json) and edit, add or remove any settings you'd like for your Foam workspace.
 
-To learn more about how to use **Foam**, read the [Recipes](https://foambubble.github.io/foam/recipes) bubbles of the Foam documentation workspace.
+To learn more about how to use **Foam**, read the [Recipes](https://foambubble.github.io/foam/recipes/recipes) bubbles of the Foam documentation workspace.
 
 
 ## Using Foam


### PR DESCRIPTION
The "Recipes" link in `readme.md` broke about a month ago [here](https://github.com/foambubble/foam/commit/deb77328c0526c1d3cdbfad9fc8c444d3a59df23#diff-c5c26860f34eeb3804c3925d45658451f670e6ac2d71a29e2a7be8020c934bfa).