### PR TITLE
Remove Markdown Links extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,9 +17,6 @@
     // [[wiki-links]], backlinking etc
     "kortina.vscode-markdown-notes",
 
-    // Adds `show graph` command that displays graph of linked notes
-    "tchayen.markdown-links",
-
     // Understated grayscale theme (light and dark variants)
     "philipbe.theme-gray-matter"
   ]


### PR DESCRIPTION
It seems like this extension is not recommended anymore. See https://github.com/foambubble/foam/commit/6ca800b50038e6ab6497917af9e892c57f310ecf