### PR TITLE
Remove color theme auto detection from settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,5 @@
   "spellright.notificationClass": "warning",
   "vscodeMarkdownNotes.noteCompletionConvention": "noExtension",
   "vscodeMarkdownNotes.slugifyMethod": "github-slugger",
-  "window.autoDetectColorScheme": true,
+  "window.autoDetectColorScheme": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,4 @@
   "spellright.notificationClass": "warning",
   "vscodeMarkdownNotes.noteCompletionConvention": "noExtension",
   "vscodeMarkdownNotes.slugifyMethod": "github-slugger",
-  "window.autoDetectColorScheme": false,
 }


### PR DESCRIPTION
This addresses https://github.com/foambubble/foam/issues/503

From the docs:
> ### Auto switch Theme based on OS color scheme
> 
> Windows and macOS now support light and dark color schemes. There is a new setting, window.autoDetectColorScheme, that instructs VS Code to listen to changes to the OS's color scheme and switch to a matching theme accordingly.

https://code.visualstudio.com/updates/v1_42#_auto-switch-theme-based-on-os-color-scheme

--- 

This setting should not be set, since it allows VSCode to override the current theme based on the OS.
This should be left up to the user to decide.