### PR TITLE
[TRIVIAL] Use ISO 8601 for date in template

### DIFF
--- a/.foam/templates/your-first-template.md
+++ b/.foam/templates/your-first-template.md
@@ -14,7 +14,7 @@ Below you can see an example showing a todo list and a timestamp.
 2. ${2:A second tabstop}
 3. ${3:A third tabstop}
 
-Note Created: ${CURRENT_YEAR}${CURRENT_MONTH}${CURRENT_DATE}
+Note Created: ${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}
 
 ---
 


### PR DESCRIPTION
As it stands, it mashes all the segments together, so it doesn't look like anything.

Use [ISO 8601](https://xkcd.com/1179/) (matches the default `foam.openDailyNote.filenameFormat`)