### PR TITLE
Add 'Markdown Notes' to recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,5 +13,8 @@
 
     // Spell checking for text, markdown and latex
     "ban.spellright",
+
+    // For creating linked notes with [[page]]
+    "kortina.vscode-markdown-notes"
   ]
 }


### PR DESCRIPTION
Markdown Notes was missing from the recommended VSCode extensions.