### PR TITLE
add shortcut-list

### DIFF
--- a/docs/how-to/shortcut-list.md
+++ b/docs/how-to/shortcut-list.md
@@ -1,0 +1,13 @@
+# Shortcut-List
+
+You can use either the name or the id to find each shortcut in the settings (File > Preferences > Keyboard Shortcuts) and find out what it is bound to on your system and change it according to your liking.
+
+| Shortcut       | Name            | ID                                      | Extension           | Use                                 |
+| -------------- | --------------- | --------------------------------------- | ------------------- | ----------------------------------- |
+| `alt+c`        | \-              | markdown.extension.checkTaskList        | Markdown All in One | Toggle TODO items.                  |
+| `cmd+b`        | \-              | markdown.extension.editing.toggleBold   | Markdown All in One | Make selection bold.                |
+| `cmd+i`        | \-              | markdown.extension.editing.toggleItalic | Markdown All in One | Make selection italic.              |
+| `ctrl+shift+f` | Format Document | editor.action.formatDocument            | Base                | Format tables                       |
+| `cmd+shift+f`  | Find files      | workbench.action.findInFiles            | Base                | Search in workspace.                |
+| `cmd+shift+e`  | Show Explorer   | workbench.view.explorer                 | Base                | Show the file explorer.             |
+| `cmd+alt+v`    | Paste Image     | extension.pasteImage                    | Paste Image         | Paste an image from your clipboard. |

--- a/docs/how-to/use-keyboard-shortcuts-for-editing.md
+++ b/docs/how-to/use-keyboard-shortcuts-for-editing.md
@@ -1,6 +1,7 @@
 # Use Keyboard Shortcuts for Editing
 
 Here are some keyboard shortcuts you'll love when editing your notes.
+>If you are not on mac or are using non-default shortcuts you can check the [[shortcut-list]] for each shortcut used in this note!
 
 This works best if you can see the result in the preview panel, run the `Markdown: Open Preview to the Side` command.
 


### PR DESCRIPTION
Add some documentation about the shortcuts used in the examples to allow people to find them in the settings in case the differ from the mac default.

Closes foambubble/foam/issues/824