### PR TITLE
Add `foam-docs` type front matter do documentation notes

### DIFF
--- a/docs/features/backlinking.md
+++ b/docs/features/backlinking.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Backlinking
 
 When using [[wikilinks]], you can find all notes that link to a specific note in the **Connections Explorer**

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Foam Commands
 
 Foam has various commands that you can explore by calling the command palette and typing "Foam".

--- a/docs/features/custom-markdown-preview-styles.md
+++ b/docs/features/custom-markdown-preview-styles.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Custom Markdown Preview Styles
 
 Visual Studio Code allows you to use your own CSS in the Markdown preview tab.

--- a/docs/features/custom-snippets.md
+++ b/docs/features/custom-snippets.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Adding Custom Snippets
 
 You can add custom snippets whilst the default set of snippets are decided by following the below steps:

--- a/docs/features/daily-notes.md
+++ b/docs/features/daily-notes.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Daily Notes
 
 Daily notes allow you to quickly create and access a new notes file for each day. This is a surpisingly effective and increasingly common strategy to organize notes and manage events.

--- a/docs/features/graph-visualization.md
+++ b/docs/features/graph-visualization.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Graph Visualization
 
 Foam comes with a graph visualization of your notes.

--- a/docs/features/including-notes.md
+++ b/docs/features/including-notes.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Including notes in a note
 
 In some situations it might be useful to include the content of another note in your current note. Foam supports this displaying within the vscode environment. Note, this does not work out-of-the-box for your publishing solutions.

--- a/docs/features/link-reference-definitions.md
+++ b/docs/features/link-reference-definitions.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Link Reference Definitions
 
 When you use `[[wikilinks]]`, the [foam-vscode](https://github.com/foambubble/foam/tree/master/packages/foam-vscode) extension can automatically generate [Markdown Link Reference Definitions](https://spec.commonmark.org/0.29/#link-reference-definitions) at the bottom of the file. This is not needed to navigate your workspace with foam-vscode, but is useful for files to remain compatible with various Markdown tools (e.g. parsers, static site generators, VS code plugins etc), which don't support `[[wikilinks]]`.

--- a/docs/features/note-properties.md
+++ b/docs/features/note-properties.md
@@ -1,5 +1,5 @@
 ---
-type: feature
+type: foam-docs
 keywords: hello world, bonjour
 tags: [hello, bonjour]
 ---
@@ -14,12 +14,12 @@ For example, for this file, we have:
 
 ```markdown
 ---
-type: feature
+type: foam-docs
 keywords: hello world, bonjour
 ---
 ```
 
-This sets the `type` of this document to `feature` and sets **three** keywords for the document: `hello`, `world`, and `bonjour`. The YAML parser will treat both spaces and commas as the separators for these YAML properties. If you want to use multi-word values for these properties, you will need to combine the words with dashes or underscores (i.e. instead of `hello world`, use `hello_world` or `hello-world`).
+This sets the `type` of this document to `foam-docs` and sets **three** keywords for the document: `hello`, `world`, and `bonjour`. The YAML parser will treat both spaces and commas as the separators for these YAML properties. If you want to use multi-word values for these properties, you will need to combine the words with dashes or underscores (i.e. instead of `hello world`, use `hello_world` or `hello-world`).
 
 > You can set as many custom properties for a document as you like, but there are a few [special properties](#special-properties) defined by Foam.
 

--- a/docs/features/note-templates.md
+++ b/docs/features/note-templates.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Note Templates
 
 Foam supports note templates which let you customize the starting content of your notes instead of always starting from an empty note.

--- a/docs/features/paste-images-from-clipboard.md
+++ b/docs/features/paste-images-from-clipboard.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Paste Images from Clipboard
 
 By installing the [vscode-paste-image](https://github.com/mushanshitiancai/vscode-paste-image) extension, you can paste an image from the clipboard with `cmd+alt+v`.

--- a/docs/features/resource-filters.md
+++ b/docs/features/resource-filters.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Resource Filters
 
 Resource filters can be passed to some Foam commands to limit their scope.

--- a/docs/features/spell-checking.md
+++ b/docs/features/spell-checking.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Spell Checking
 
 There are many spell checking extensions for VS Code.

--- a/docs/features/tags.md
+++ b/docs/features/tags.md
@@ -1,4 +1,5 @@
 ---
+type: foam-docs
 tags: my-tag1 my-tag2 my-tag3/notes
 ---
 

--- a/docs/features/wikilinks.md
+++ b/docs/features/wikilinks.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Wikilinks
 
 Wikilinks are the internal links that connect the files in your knowledge base. (Also called `[[MediaWiki]]` links).

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Frequently Asked Questions
 
 > ⚠️ Foam is still in preview. Expect the experience to be a little rough.

--- a/docs/getting-started/creating-new-notes.md
+++ b/docs/getting-started/creating-new-notes.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Creating New Notes
 
 - Write out a new `[[wikilink]]` and `Cmd` + `Click` to create a new file and enter it.

--- a/docs/getting-started/get-started-with-vscode.md
+++ b/docs/getting-started/get-started-with-vscode.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Getting started with VS Code
 
 VS Code is a powerful text editor, hidden behind a simple interface.

--- a/docs/getting-started/keyboard-shortcuts.md
+++ b/docs/getting-started/keyboard-shortcuts.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Keyboard Shortcuts
 
 Here are some keyboard shortcuts you'll love when editing your notes.

--- a/docs/getting-started/recommended-extensions.md
+++ b/docs/getting-started/recommended-extensions.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Recommended Extensions
 
 These extensions defined in `.vscode/extensions.json` are automatically installed when you accept the workspace's recommended extensions.

--- a/docs/getting-started/sync-notes-with-source-control.md
+++ b/docs/getting-started/sync-notes-with-source-control.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Sync notes with source control
 
 Source control is a way to precicely manage the history and content of a directory of files.

--- a/docs/getting-started/write-notes-in-foam.md
+++ b/docs/getting-started/write-notes-in-foam.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Writing Notes
 
 Notes are simple text files with some extra flavor, in the shape of Markdown syntax and support for extra properties (see [[note-properties]]).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Using Foam
 
 Foam is a collection VS Code extensions and recipes that power up the editor

--- a/docs/publishing/generate-gatsby-site.md
+++ b/docs/publishing/generate-gatsby-site.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Generate a site using Gatsby
 
 ## Using foam-gatsby-template

--- a/docs/publishing/math-support-with-katex.md
+++ b/docs/publishing/math-support-with-katex.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Katex Math Rendering
 
 Apart from using the method mentioned in [[math-support-with-mathjax]], we can also use KaTeX to render our math equations in Foam. The caveat is: we can't rely on GitHub Pages to host and deploy our website anymore, because the plugin we'll be using to let Jekyll support KaTeX doesn't play well together with GitHub Pages.

--- a/docs/publishing/math-support-with-mathjax.md
+++ b/docs/publishing/math-support-with-mathjax.md
@@ -1,4 +1,5 @@
 ---
+type: foam-docs
 layout: mathjax
 ---
 

--- a/docs/publishing/publish-to-azure-devops-wiki.md
+++ b/docs/publishing/publish-to-azure-devops-wiki.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Publish to Azure DevOps Wiki
 
 Publish your Foam workspace as an Azure DevOps wiki.

--- a/docs/publishing/publish-to-github-pages.md
+++ b/docs/publishing/publish-to-github-pages.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # GitHub Pages
 
 1. In VSCode workspace settings set `"foam.edit.linkReferenceDefinitions": "withoutExtensions"`

--- a/docs/publishing/publish-to-github.md
+++ b/docs/publishing/publish-to-github.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Publish to GitHub
 
 The standard [foam-template](https://github.com/foambubble/foam-template) is ready to be published to GitHub, and GitHub pages.

--- a/docs/publishing/publish-to-gitlab-pages.md
+++ b/docs/publishing/publish-to-gitlab-pages.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # GitLab Pages
 
 You don't have to use GitHub to serve Foam pages. You can also use GitLab.

--- a/docs/publishing/publish-to-netlify-with-eleventy.md
+++ b/docs/publishing/publish-to-netlify-with-eleventy.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Publish to Netlify with Eleventy
 
 You can use [foam-eleventy-template](https://github.com/juanfrank77/foam-eleventy-template) to generate a static site with [Eleventy](https://www.11ty.dev/), and host it online on [Netlify](https://www.netlify.com/).

--- a/docs/publishing/publish-to-vercel.md
+++ b/docs/publishing/publish-to-vercel.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Publish to Vercel
 
 This #recipe shows you how to deploy the default Foam website template to Vercel.

--- a/docs/publishing/publishing.md
+++ b/docs/publishing/publishing.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Publishing pages
 
 Foam pages can be published.

--- a/docs/recipes/add-images-to-notes.md
+++ b/docs/recipes/add-images-to-notes.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Add images to your notes
 
 This #recipe allows you to paste images on to your notes.

--- a/docs/recipes/automatic-git-syncing.md
+++ b/docs/recipes/automatic-git-syncing.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Automatically Sync with Git
 
 With this #recipe you can regularly commit and push to git, to keep your repo in always synched.

--- a/docs/recipes/automatically-expand-urls-to-well-titled-links.md
+++ b/docs/recipes/automatically-expand-urls-to-well-titled-links.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Automatically Expand URLs to Well-Titled Links
 
 With this #recipe you can convert a link to a fully-formed Markdown link, using the page's title as a display name. Useful for citations and creating link collections.

--- a/docs/recipes/capture-notes-with-drafts-pro.md
+++ b/docs/recipes/capture-notes-with-drafts-pro.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Capture Notes With Drafts Pro
 
 With this #recipe you can create notes on your iOS device, which will automatically be imported into Foam.

--- a/docs/recipes/capture-notes-with-shortcuts-and-github-actions.md
+++ b/docs/recipes/capture-notes-with-shortcuts-and-github-actions.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Capture Notes With Shortcuts and GitHub Actions
 
 With this #recipe you can create notes on your iOS device, which will automatically be imported into Foam.

--- a/docs/recipes/diagrams-in-markdown.md
+++ b/docs/recipes/diagrams-in-markdown.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Diagrams in Markdown
 
 We have two alternative #recipe for displaying diagrams in markdown:

--- a/docs/recipes/how-to-write-recipes.md
+++ b/docs/recipes/how-to-write-recipes.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # How to Write Recipes
 
 This is an example of how to structure a Recipe. The first paragraph or two should explain the purpose of the recipe succinctly, including why it's useful, if that's not obvious.

--- a/docs/recipes/make-backlinks-more-prominent.md
+++ b/docs/recipes/make-backlinks-more-prominent.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Make Backlinks More Prominent
 
 One of the most most common early feature requests in Foam is to make the Markdown Notes Backlinks Explorer more prominent.

--- a/docs/recipes/markup-converter.md
+++ b/docs/recipes/markup-converter.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Markup Converter
 
 This #recipe allows you to convert any document into Markdown for storing them in your notes.

--- a/docs/recipes/migrating-from-obsidian.md
+++ b/docs/recipes/migrating-from-obsidian.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Migrating from Obsidian (stub)
 
 **[[todo]] This [[roadmap]] item needs more specification work.**

--- a/docs/recipes/migrating-from-onenote.md
+++ b/docs/recipes/migrating-from-onenote.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Migrating from OneNote
 
 This guide mostly duplicates the instructions at the repo for the PowerShell [script](https://github.com/nixsee/ConvertOneNote2MarkDown).

--- a/docs/recipes/migrating-from-roam.md
+++ b/docs/recipes/migrating-from-roam.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Migrating from Roam (stub)
 
 **[[todo]] This [[roadmap]] item needs more specification work.**

--- a/docs/recipes/note-macros.md
+++ b/docs/recipes/note-macros.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Custom Note Macros
 
 This #recipe allows you to create custom note macros.

--- a/docs/recipes/predefined-user-snippets.md
+++ b/docs/recipes/predefined-user-snippets.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Pre-defined User Snippets
 
 This #recipe allows us to introduce Roam style commands to Foam, by using [VS Code Snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets). Consider the below snippets:

--- a/docs/recipes/real-time-collaboration.md
+++ b/docs/recipes/real-time-collaboration.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Real-time Collaboration
 
 This #recipe is here to just tell you that VS Code Live Share will allow you to collaborate live on your notes.

--- a/docs/recipes/search-for-notes.md
+++ b/docs/recipes/search-for-notes.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Search for Notes
 
 This #recipe contains tips on how to leverage VS Code search features.

--- a/docs/recipes/shows-image-preview-on-hover.md
+++ b/docs/recipes/shows-image-preview-on-hover.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Shows Image Preview on Hover
 
 This #recipe allows you to see a preview of an image on hover.

--- a/docs/recipes/take-notes-from-mobile-phone.md
+++ b/docs/recipes/take-notes-from-mobile-phone.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Take notes on mobile phones
 
 This #recipe offers solutions to taking Foam notes on the go.

--- a/docs/recipes/web-clipper.md
+++ b/docs/recipes/web-clipper.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Web Clipper
 
 This #recipe allows you to convert any web content into Markdown for storing them in your notes.

--- a/docs/recipes/write-your-notes-in-github-gist.md
+++ b/docs/recipes/write-your-notes-in-github-gist.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Write your notes in GitHub Gist
 
 This #recipe will allow you to persist your notes in a GitHub repository, and automatically sync changes without needing to manually commit/push/pull, then GistPad might be an option worth exploring.

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Command Line Interface
 
 Create a CLI tool to allow running common Foam commands. These may include:

--- a/docs/tools/foam-logging-in-vscode.md
+++ b/docs/tools/foam-logging-in-vscode.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Foam logging in VsCode
 
 The Foam extension logs details about what its doing in vscode's `Output` tab.

--- a/docs/tools/orphans.md
+++ b/docs/tools/orphans.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Orphaned Notes
 
 Foam helps you to find orphans: notes that have neither forward links nor backlinks.

--- a/docs/tools/workspace-janitor.md
+++ b/docs/tools/workspace-janitor.md
@@ -1,3 +1,6 @@
+---
+type: foam-docs
+---
 # Janitor
 
 To store your personal knowledge graph in markdown files instead of a database, we need some additional tooling to create and maintain relationships with notes.


### PR DESCRIPTION
Hello! Foam has received a lot of cool new features since I last contributed and I notice the template documentation is much richer. Well done, everyone!

I've added the `type: foam-docs` to the documentation notes so that people can more easily filter them out when they want to visualize their graphs.

@riccardoferretti, let me know what you think?

Cheers!