### PR TITLE
fixed broken link for keyboard shortcuts

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -6,7 +6,7 @@ Welcome to your new foam workspace, let's get you started.
 
 Let's go through this to set up your repo:
 
-- [ ] if you are new with VS Code, see how to [[get-started-with-vscode]] and how to [[use-keyboard-shortcuts-for-editing]]
+- [ ] if you are new with VS Code, see how to [[get-started-with-vscode]] and how to use [[keyboard-shortcuts]] for editing.
 
 - [ ] you can navigate the links between your notes by `cmd+click` (or `ctrl+click` on Windows) on a wikilink. You can go back with `ctrl+-`. Here, go to your [[inbox]]
 


### PR DESCRIPTION
Found it likely broke it the past.

I assume this part is Specific for this repository so I created a PR here instead of in the main repo